### PR TITLE
Fix Missing Exports Condition warning

### DIFF
--- a/packages/icons-svelte/package.json
+++ b/packages/icons-svelte/package.json
@@ -26,6 +26,14 @@
   "files": [
     "dist"
   ],
+  "exports": {
+    ".": {
+      "types": "./dist/tabler-icons-svelte.d.ts",
+      "svelte": "./dist/svelte/tabler-icons-svelte.js"
+    },
+    "./dist/svelte/Icon.svelte": "./dist/svelte/Icon.svelte",
+    "./dist/svelte/icons/*.svelte": "./dist/svelte/icons/*.svelte"
+  },
   "scripts": {
     "build": "pnpm run clean && pnpm run copy:license && pnpm run build:icons && pnpm run build:bundles && pnpm build:strip",
     "build:icons": "node build.mjs",


### PR DESCRIPTION
Fix warning [Missing Exports Condition](https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition)

![CleanShot 2023-12-14 at 22 35 00@2x](https://github.com/sadovojav/tabler-icons/assets/9282021/936d6621-3113-4118-ad13-0234ad8f9d01)

This warning occurs when using @sveltejs/vite-plugin-svelte
